### PR TITLE
Fix React Native Elements Card type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "build": "tsc --noEmit"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.4",

--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView, Image } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Card } from 'react-native-elements';
+import { Card as ElementsCard } from 'react-native-elements';
+
+const CardContainer = ElementsCard as React.ComponentType<
+  React.ComponentProps<typeof ElementsCard> & { children?: React.ReactNode }
+>;
 
 export default function AboutScreen() {
   return (
@@ -20,27 +24,27 @@ export default function AboutScreen() {
           passed down through generations.
         </Text>
         
-        <Card containerStyle={styles.card}>
-          <Card.Title>Our Mission</Card.Title>
-          <Card.Divider />
+        <CardContainer containerStyle={styles.card}>
+          <ElementsCard.Title>Our Mission</ElementsCard.Title>
+          <ElementsCard.Divider />
           <Text style={styles.cardText}>
             At DevSwaD, our mission is to celebrate and promote the rich culinary heritage of Bihar 
             while supporting local farmers and artisans. We strive to deliver premium quality, 
             authentic Bihari products that not only tantalize taste buds but also contribute to 
             the well-being of our customers and communities.
           </Text>
-        </Card>
+        </CardContainer>
         
         <Text style={styles.sectionTitle}>Our Values</Text>
         {['Authenticity', 'Quality', 'Sustainability'].map((value, index) => (
-          <Card key={index} containerStyle={styles.card}>
-            <Card.Title>{value}</Card.Title>
-            <Card.Divider />
+          <CardContainer key={index} containerStyle={styles.card}>
+            <ElementsCard.Title>{value}</ElementsCard.Title>
+            <ElementsCard.Divider />
             <Text style={styles.cardText}>
               We are committed to {value.toLowerCase()} in every aspect of our business, 
               from sourcing ingredients to delivering products to your doorstep.
             </Text>
-          </Card>
+          </CardContainer>
         ))}
       </ScrollView>
     </SafeAreaView>

--- a/src/screens/ContactScreen.tsx
+++ b/src/screens/ContactScreen.tsx
@@ -1,8 +1,12 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Input, Button, Card } from 'react-native-elements';
+import { Input, Button, Card as ElementsCard } from 'react-native-elements';
 import { Ionicons } from '@expo/vector-icons';
+
+const CardContainer = ElementsCard as React.ComponentType<
+  React.ComponentProps<typeof ElementsCard> & { children?: React.ReactNode }
+>;
 
 export default function ContactScreen() {
   const [name, setName] = useState('');
@@ -25,7 +29,7 @@ export default function ContactScreen() {
       <ScrollView>
         <Text style={styles.title}>Contact Us</Text>
         
-        <Card containerStyle={styles.card}>
+        <CardContainer containerStyle={styles.card}>
           <Input
             placeholder="Your Name"
             leftIcon={<Ionicons name="person-outline" size={24} color="#2E8B57" />}
@@ -52,11 +56,11 @@ export default function ContactScreen() {
             onPress={handleSubmit}
             buttonStyle={styles.submitButton}
           />
-        </Card>
+        </CardContainer>
         
-        <Card containerStyle={styles.card}>
-          <Card.Title>Contact Information</Card.Title>
-          <Card.Divider />
+        <CardContainer containerStyle={styles.card}>
+          <ElementsCard.Title>Contact Information</ElementsCard.Title>
+          <ElementsCard.Divider />
           <View style={styles.contactItem}>
             <Ionicons name="location-outline" size={24} color="#2E8B57" />
             <Text style={styles.contactText}>123 Bihar Street, Patna, Bihar 800001</Text>
@@ -69,15 +73,15 @@ export default function ContactScreen() {
             <Ionicons name="mail-outline" size={24} color="#2E8B57" />
             <Text style={styles.contactText}>info@devswad.com</Text>
           </View>
-        </Card>
+        </CardContainer>
         
-        <Card containerStyle={styles.card}>
-          <Card.Title>Business Hours</Card.Title>
-          <Card.Divider />
+        <CardContainer containerStyle={styles.card}>
+          <ElementsCard.Title>Business Hours</ElementsCard.Title>
+          <ElementsCard.Divider />
           <Text style={styles.businessHours}>Monday - Friday: 9:00 AM - 6:00 PM</Text>
           <Text style={styles.businessHours}>Saturday: 10:00 AM - 4:00 PM</Text>
           <Text style={styles.businessHours}>Sunday: Closed</Text>
-        </Card>
+        </CardContainer>
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
Fixes #1.

## Summary
- Adds a `build` script that runs `tsc --noEmit`
- Fixes the React Native Elements `Card` children type errors in `AboutScreen.tsx` and `ContactScreen.tsx`
- Keeps `Card.Title` and `Card.Divider` on the original component so runtime behavior stays unchanged

## Verification
```bash
npm run build
```

For the bounty payment after review/merge, please contact me via GitHub @xingxi0614-cpu. I can provide a payment method privately.